### PR TITLE
Update color schemes to Solarized Dark for better contrast

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -36,8 +36,8 @@
 	remote = cyan bold
 
 [color "diff"]
-	meta = yellow bold
-	frag = magenta bold
+	meta = blue bold
+	frag = cyan bold
 	old = red bold
 	new = green bold
 	whitespace = red reverse

--- a/zsh/oh-my-zsh-custom/modern-tools.zsh
+++ b/zsh/oh-my-zsh-custom/modern-tools.zsh
@@ -4,14 +4,17 @@
 if command -v bat &> /dev/null; then
   alias cat='bat --paging=never'
   alias catp='bat'  # bat with pager
-  export BAT_THEME="TwoDark"
+  export BAT_THEME="Solarized (dark)"
   export MANPAGER="sh -c 'col -bx | bat -l man -p'"
 fi
 
 # eza - better ls
 if command -v eza &> /dev/null; then
-  # Solarized-inspired color scheme (more subdued, readable on dark backgrounds)
-  export EZA_COLORS="reset:di=1;34:ln=1;36:so=35:pi=33:ex=32:bd=33:cd=33:su=31:sg=31:tw=1;34:ow=1;34"
+  # Solarized Dark color scheme (optimized for black backgrounds)
+  # di=directories, ln=symlinks, ex=executables, da=date/timestamp, uu=user, etc.
+  # Using Solarized colors: blue=34, cyan=36, green=32, yellow=33, red=31, magenta=35
+  # Muted colors (non-bold) for timestamps and user info
+  export EZA_COLORS="reset:di=1;34:ln=1;36:so=1;35:pi=33:ex=1;32:bd=33:cd=33:su=37;41:sg=30;43:tw=30;42:ow=34:da=36:uu=33"
 
   alias ls='eza --icons --color=auto'
   alias ll='eza -l --icons --git --color=auto'


### PR DESCRIPTION
## Summary

Updates all CLI tool color schemes from generic/bright colors to Solarized Dark palette for consistent, readable colors optimized for dark terminal backgrounds.

### Changes Made

**bat:**
- Changed theme from TwoDark to Solarized (dark)
- Better syntax highlighting on black backgrounds

**eza:**
- Updated to Solarized Dark color palette
- Directories: bold blue, Symlinks: bold cyan, Executables: bold green
- Timestamps: muted cyan (non-bold)
- User info: muted yellow (non-bold)

**git:**
- Updated diff colors: meta (blue), frag/line numbers (cyan)
- Consistent Solarized colors for status, diff, and log

### Benefits

- Consistent Solarized Dark palette across all tools
- Better contrast and readability on black backgrounds
- Less eye strain from overly bright colors
- Muted metadata doesn't distract from content
- Professional, cohesive visual experience

## Test Plan

All tests passed:
- [x] bat displays code with Solarized Dark syntax highlighting
- [x] eza shows directories in bold blue, executables in bold green
- [x] eza timestamps and user info are muted and readable
- [x] git diff shows meta in blue, line numbers in cyan
- [x] git status uses appropriate Solarized colors
- [x] git lg displays log with Solarized colors
- [x] All colors work well together on black background

🤖 Generated with [Claude Code](https://claude.com/claude-code)